### PR TITLE
add autodiscovery link tag for opensearch document

### DIFF
--- a/views/header.tpl
+++ b/views/header.tpl
@@ -8,5 +8,6 @@
     <script type="text/javascript" src="static/jdpicker.js"></script>
     <link rel="stylesheet" type="text/css" href="static/jdpicker.css">
     <link rel="icon" type="image/png" href="static/recoll.png">
+    <link rel="search" type="application/opensearchdescription+xml" title="recoll" href="osd.xml">
 </head>
 <body>


### PR DESCRIPTION
Currently Firefox fails with the "Register recoll into browser search engines" in settings. Adding an autodiscovery link tag will allow recoll to be added as a search engine in Firefox.
