### PR TITLE
fix launching webui-standalone from same directory

### DIFF
--- a/webui-standalone.py
+++ b/webui-standalone.py
@@ -10,7 +10,7 @@ parser.add_argument('-p', '--port', default='8080', type=int, help='port to list
 args = parser.parse_args()
 
 # change to webui's directory and import
-os.chdir(os.path.dirname(__file__))
+os.chdir(os.path.dirname(__file__) or '.')
 
 # set up webui and run in own http server
 webui.bottle.debug(True)


### PR DESCRIPTION
When called like `python ./webui-standalone.py` `os.path.dirname(__file__)` returns an empty string.

(*lovely* interface by the way!)