### PR TITLE
Changed the value of set_cookie() 'expires' from 3x10**9  3x10**8 (10 years)

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -1422,7 +1422,7 @@ class BaseResponse(object):
             if key == 'expires':
                 if isinstance(value, (datedate, datetime)):
                     value = value.timetuple()
-                elif isinstance(value, (int, float)):
+                elif isinstance(value, (int, long, float)):
                     value = time.gmtime(value)
                 value = time.strftime("%a, %d %b %Y %H:%M:%S GMT", value)
             self._cookies[name][key.replace('_', '-')] = value

--- a/webui.py
+++ b/webui.py
@@ -342,10 +342,10 @@ def settings():
 def set():
     config = get_config()
     for k, v in DEFAULTS.items():
-        bottle.response.set_cookie(k, str(bottle.request.query.get(k)), max_age=3153600000, expires=3153600000)
+        bottle.response.set_cookie(k, str(bottle.request.query.get(k)), max_age=3153600000, expires=315360000)
     for d in config['dirs']:
         cookie_name = 'mount_%s' % urllib.quote(d, '')
-        bottle.response.set_cookie(cookie_name, str(bottle.request.query.get('mount_%s' % d)), max_age=3153600000, expires=3153600000)
+        bottle.response.set_cookie(cookie_name, str(bottle.request.query.get('mount_%s' % d)), max_age=3153600000, expires=315360000)
     bottle.redirect('./')
 #}}}
 #{{{ osd


### PR DESCRIPTION

The initial value was triggering 2038 issues or some platforms (or pure
integer overflows, did not check). Also admit long as param type inside
set_cookie() as there does not seem to be any reason not to.