### PR TITLE
Fixed bug when there are less entries than the maximum number of resu…

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -211,6 +211,10 @@ def recoll_search(q, dosnippets=True):
             doc = query.fetchone()
         except:
             break
+
+        if doc is None:
+            break
+
         d = {}
         for f in FIELDS:
             v = getattr(doc, f)


### PR DESCRIPTION
Without this bugfix I was continuously getting an error every time that the number of entries found was less then the maximum number of entries displayed. This is the error I was getting on Ubuntu 16.04.5 LTS:

`127.0.0.1 - - [26/Jun/2019 14:35:26] "GET /results?query=dichroitisc*&dir=shared%2Fprojects%2FDQSIM&after=&before=&sort=relevancyrating&ascending=0&page=1 HTTP/1.1" 500 1768
:3:common/rclinit.cpp:341::Recoll 1.25.19 + Xapian 1.2.22 [/home/recoll/.recoll]
Traceback (most recent call last):
  File "/var/www/recoll-webui-master/bottle.py", line 744, in _handle
    return route.call(**args)
  File "/var/www/recoll-webui-master/bottle.py", line 1479, in wrapper
    rv = callback(*a, **ka)
  File "/var/www/recoll-webui-master/bottle.py", line 2850, in wrapper
    result = func(*args, **kwargs)
  File "/var/www/recoll-webui-master/webui.py", line 252, in results
    res, nres, timer = recoll_search(query)
  File "/var/www/recoll-webui-master/webui.py", line 216, in recoll_search
    v = getattr(doc, f)
AttributeError: 'NoneType' object has no attribute 'ipath'`

The fix is very simple, since it stops the for loop once there are no more entries found.